### PR TITLE
Buildscript improvements, specifically related to Modrinth integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,11 @@
+import com.modrinth.minotaur.dependencies.ModDependency
+
 plugins {
-	id("fabric-loom") version "0.10-SNAPSHOT"
+	id("fabric-loom") version "0.11.+"
 	id("maven-publish")
 	id("com.github.breadmoirai.github-release") version "2.2.12"
 	id("com.matthewprenger.cursegradle") version "1.4.0"
-	id("com.modrinth.minotaur") version "1.1.0"
+	id("com.modrinth.minotaur") version "2.+"
 	id("elect86.gik") version "0.0.4"
 }
 
@@ -41,8 +43,8 @@ dependencies {
 	include("io.leangen.geantyref:geantyref:$geantyrefVersion")
 	include("com.typesafe:config:$hoconVersion")
 
-	modCompileOnly("com.github.caffeinemc:sodium-fabric:$sodiumVersion")
-	modCompileOnly("com.modrinth.starlight:starlight:$starlightVersion")
+	modCompileOnly("maven.modrinth:sodium:$sodiumVersion")
+	modCompileOnly("maven.modrinth:starlight:$starlightVersion")
 	modCompileOnly("ca.stellardrift:confabricate:$confabricateVersion")
 	modImplementation("me.shedaniel.cloth:cloth-config-fabric:$clothConfigVersion")
 	modImplementation("com.terraformersmc:modmenu:$modMenuVersion")
@@ -96,17 +98,10 @@ repositories {
 			includeGroup("com.terraformersmc")
 		}
 	}
-	ivy {
-		setUrl("https://github.com/CaffeineMC/")
-		patternLayout { artifact("[artifact]/releases/download/[revision]/[artifact]-[revision](+[classifier])(.[ext])") }
-		metadataSources { artifact() }
-		content { includeGroup("com.github.caffeinemc") }
-	}
-	ivy {
-		setUrl("https://cdn.modrinth.com/data/H8CaAYZC/versions/")
-		patternLayout { artifact("Starlight [revision] 1.18.x/[artifact]-[revision](+[classifier])(.[ext])") }
-		metadataSources { artifact() }
-		content { includeGroup("com.modrinth.starlight") }
+	maven("https://api.modrinth.com/maven") {
+		content {
+			includeGroup("maven.modrinth")
+		}
 	}
 }
 
@@ -157,20 +152,28 @@ tasks.withType<com.matthewprenger.cursegradle.CurseUploadTask> {
 	dependsOn(tasks.remapJar)
 }
 
-val publishModrinth by tasks.registering(com.modrinth.minotaur.TaskModrinthUpload::class) {
+tasks.modrinth {
 	dependsOn(tasks.remapJar)
-	token = project.property("modrinth.token") as String
-	projectId = project.property("modrinth.id") as String
-	versionNumber = "${project.version}"
-	uploadFile = tasks.remapJar.flatMap { it.archiveFile }
-	changelog = readChangelog()
-	releaseType = "release"
-	addLoader("fabric")
-	addGameVersion(minecraftVersion)
+}
+
+modrinth {
+	token.set(project.property("modrinth.token") as String)
+	projectId.set(project.property("modrinth.id") as String)
+	uploadFile.set(tasks.remapJar.get())
+	changelog.set(readChangelog())
+	versionType.set("release")
+	loaders.set(listOf("fabric"))
+	gameVersions.set(listOf(minecraftVersion))
+	dependencies.set(
+		listOf(
+			ModDependency("AANobbMI", "optional"), // Sodium
+			ModDependency("mOgUt4GM", "optional"), // Mod Menu
+		)
+	)
 }
 
 val publishAll by tasks.registering {
 	dependsOn(tasks.curseforge)
 	dependsOn(tasks.githubRelease)
-	dependsOn(publishModrinth)
+	dependsOn(tasks.modrinth)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,5 @@
-import com.modrinth.minotaur.dependencies.ModDependency
-
 plugins {
-	id("fabric-loom") version "0.11.+"
+	id("fabric-loom") version "0.12.+"
 	id("maven-publish")
 	id("com.github.breadmoirai.github-release") version "2.2.12"
 	id("com.matthewprenger.cursegradle") version "1.4.0"
@@ -157,19 +155,16 @@ tasks.modrinth {
 }
 
 modrinth {
+	debugMode.set(true)
 	token.set(project.property("modrinth.token") as String)
 	projectId.set(project.property("modrinth.id") as String)
 	uploadFile.set(tasks.remapJar.get())
 	changelog.set(readChangelog())
-	versionType.set("release")
-	loaders.set(listOf("fabric"))
-	gameVersions.set(listOf(minecraftVersion))
-	dependencies.set(
-		listOf(
-			ModDependency("AANobbMI", "optional"), // Sodium
-			ModDependency("mOgUt4GM", "optional"), // Mod Menu
-		)
-	)
+	dependencies {
+		optional.project("9s6osm5g") // Cloth Config
+		optional.project("mOgUt4GM") // Mod Menu
+		optional.project("AANobbMI") // Sodium
+	}
 }
 
 val publishAll by tasks.registering {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -155,8 +155,7 @@ tasks.modrinth {
 }
 
 modrinth {
-	debugMode.set(true)
-	token.set(project.property("modrinth.token") as String)
+	token.set(project.findProperty("modrinth.token") as String? ?: "DUMMY")
 	projectId.set(project.property("modrinth.id") as String)
 	uploadFile.set(tasks.remapJar.get())
 	changelog.set(readChangelog())

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx2G
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
 	minecraftVersion=1.18.2
-	yarnMappings=1.18.2+build.2
-	loaderVersion=0.13.3
+	yarnMappings=1.18.2+build.3
+	loaderVersion=0.14.5
 
 # Mod Properties
 	modVersion = 3.1.1
@@ -19,12 +19,12 @@ org.gradle.jvmargs=-Xmx2G
 	modrinth.token = ***
 
 # Dependencies
-	fabricApiVersion = 0.47.10+1.18.2
+	fabricApiVersion = 0.51.1+1.18.2
 	configurateVersion = 4.1.2
 	geantyrefVersion = 1.3.13
 	hoconVersion = 1.4.2
 	confabricateVersion = 2.1.0
-	clothConfigVersion = 6.0.42
-	modMenuVersion = 3.1.0
+	clothConfigVersion = 6.2.62
+	modMenuVersion = 3.2.2
 	sodiumVersion = mc1.18.2-0.4.1
 	starlightVersion = 1.0.2+1.18.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
-	# check these on https://fabricmc.net/use
+	# check these on https://fabricmc.net/develop
 	minecraftVersion=1.18.2
 	yarnMappings=1.18.2+build.2
 	loaderVersion=0.13.3
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx2G
 	modrinth.id = M08ruV16
 	# github.token = ***
 	# curseforge.token = ***
-	# modrinth.token = ***
+	modrinth.token = ***
 
 # Dependencies
 	fabricApiVersion = 0.47.10+1.18.2
@@ -25,6 +25,6 @@ org.gradle.jvmargs=-Xmx2G
 	hoconVersion = 1.4.2
 	confabricateVersion = 2.1.0
 	clothConfigVersion = 6.0.42
-	modMenuVersion = 3.0.0
-	sodiumVersion = mc1.18-0.4.0-alpha5:build.9
-	starlightVersion = 1.0.0:fabric.d0a3220
+	modMenuVersion = 3.1.0
+	sodiumVersion = mc1.18.2-0.4.1
+	starlightVersion = 1.0.2+1.18.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx2G
 	modrinth.id = M08ruV16
 	# github.token = ***
 	# curseforge.token = ***
-	modrinth.token = ***
+	# modrinth.token = ***
 
 # Dependencies
 	fabricApiVersion = 0.51.1+1.18.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven("https://maven.fabricmc.net/")
         gradlePluginPortal()
     }


### PR DESCRIPTION
- Update Fabric Loom to 0.12.+
- Update Minotaur to 2.+
- Use Modrinth Maven instead of janky setup for pulling Sodium and Starlight
- Update a couple dependencies
- Remove jcenter