### PR TITLE
Sodium 0.5 official branch - ClientWorld is null

### DIFF
--- a/src/main/java/de/johni0702/minecraft/bobby/mixin/sodium/SodiumChunkManagerMixin.java
+++ b/src/main/java/de/johni0702/minecraft/bobby/mixin/sodium/SodiumChunkManagerMixin.java
@@ -6,15 +6,15 @@ import me.jellysquid.mods.sodium.client.render.chunk.map.ChunkTrackerHolder;
 import net.minecraft.client.world.ClientChunkManager;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.math.ChunkSectionPos;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(value = ClientChunkManager.class, priority = 1010) // higher than our normal one
 public abstract class SodiumChunkManagerMixin implements ClientChunkManagerExt {
-    private final ClientWorld world;
 
-    protected SodiumChunkManagerMixin(ClientWorld world) {
-        this.world = world;
-    }
+    @Shadow @Final
+    ClientWorld world;
 
     @Override
     public void bobby_onFakeChunkAdded(int x, int z) {


### PR DESCRIPTION
When opening a world the game will crash due to the ClientWorld within SodiumChunkManagerMixin being null causing the below crash

```
java.lang.NullPointerException: Cannot invoke "me.jellysquid.mods.sodium.client.render.chunk.map.ChunkTrackerHolder.sodium$getTracker()" because "world" is null
	at me.jellysquid.mods.sodium.client.render.chunk.map.ChunkTrackerHolder.get(ChunkTrackerHolder.java:7)
	at net.minecraft.class_631.bobby_onFakeChunkAdded(class_631.java:2522)
	at de.johni0702.minecraft.bobby.FakeChunkManager.load(FakeChunkManager.java:298)
	at de.johni0702.minecraft.bobby.FakeChunkManager$LoadingJob.lambda$complete$1(FakeChunkManager.java:409)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at de.johni0702.minecraft.bobby.FakeChunkManager$LoadingJob.complete(FakeChunkManager.java:409)
	at de.johni0702.minecraft.bobby.FakeChunkManager.update(FakeChunkManager.java:251)
	at de.johni0702.minecraft.bobby.FakeChunkManager.update(FakeChunkManager.java:128)
	at net.minecraft.class_310.handler$zbi000$bobby$bobbyUpdate(class_310.java:4028)
	at net.minecraft.class_310.method_1523(class_310.java:1178)
	at net.minecraft.class_310.method_1514(class_310.java:802)
	at net.minecraft.client.main.Main.main(Main.java:250)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:468)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:578)
	at org.polymc.impl.OneSixLauncher.invokeMain(OneSixLauncher.java:104)
	at org.polymc.impl.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:176)
	at org.polymc.impl.OneSixLauncher.launch(OneSixLauncher.java:186)
	at org.polymc.EntryPoint.listen(EntryPoint.java:144)
	at org.polymc.EntryPoint.main(EntryPoint.java:74)
```

