### PR TITLE
Fix dynamic world management on servers with multiple instances

### DIFF
--- a/src/main/java/de/johni0702/minecraft/bobby/FakeChunkManager.java
+++ b/src/main/java/de/johni0702/minecraft/bobby/FakeChunkManager.java
@@ -112,6 +112,7 @@ public class FakeChunkManager {
 
         if (config.isDynamicMultiWorld()) {
             worlds = Worlds.getFor(storagePath);
+            worlds.startNewWorld();
             storages.add(worlds::loadTag);
 
             storage = null;

--- a/src/main/java/de/johni0702/minecraft/bobby/Worlds.java
+++ b/src/main/java/de/johni0702/minecraft/bobby/Worlds.java
@@ -154,6 +154,23 @@ public class Worlds implements AutoCloseable {
         }
     }
 
+    public void startNewWorld() {
+        // When switching from one server to another, this function can be executed multiple times
+        // Without this early return, that would create multiple empty words,
+        // after which only the last one would be merged and the empty ones would stay in memory
+        if (worlds.get(currentWorldId).regions.isEmpty()) {
+            return;
+        }
+
+        lock.writeLock().lock();
+        try {
+            currentWorldId = nextWorldId++;
+            worlds.put(currentWorldId, new World(currentWorldId, CURRENT_SAVE_VERSION));
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
     public CompletableFuture<Optional<NbtCompound>> loadTag(ChunkPos chunkPos) {
         RegionPos regionPos = RegionPos.from(chunkPos);
         long regionCoord = regionPos.toLong();


### PR DESCRIPTION
This fixes the feature on servers like Hypixel, where you change sub-servers when switching lobbies.

This (I'm pretty sure) fixes https://github.com/Johni0702/bobby/issues/250. I tested it only on Hypixel, but it works there.

First of all, I'm not writing Java on day-to-day, so the code might not be the best. However, I was able to trace what changed between the [wip version](https://github.com/Johni0702/bobby/tree/feature/multi-world) that worked on Hypixel and the current version and then apply fixes. There might be a better way to implement this fix, but it does fix the issue (at least in my testing).

The issue with Hypixel, or other big minigame servers, is that when you connect to the main IP, you're placed in a smaller server. Then, when you change the lobby, for example, when choosing a minigame, you're transported to a different server. This doesn't trigger any creation of a new map, so you still see chunks from the main lobby while you were in a minigame.

To fix this, I re-added the  `startNewWorld` function, which creates a world each time a world is loaded. The world should then be quickly merged with an existing one, if there is one in cache.

The last problem I saw was that, for some reason, when changing servers on Hypixel the newly added `startNewWorld` was triggering 3 times. I think that's because to get a fancy nether portal animation on changing servers, the server sends you first to overworld, then to nether and then to the final map. That created a lot of empty maps with 0 chunks when I was playing, and those will never get merged. To fix that, I added an early return, so if the world for the current id is empty, we can just use it instead of creating a new one.