### PR TITLE
Fix Network Protocol Error when Dynamic Multi World is Enabled

### DIFF
--- a/src/main/java/de/johni0702/minecraft/bobby/Worlds.java
+++ b/src/main/java/de/johni0702/minecraft/bobby/Worlds.java
@@ -1040,8 +1040,8 @@ public class Worlds implements AutoCloseable {
                     NbtCompound matchNbt = (NbtCompound) matchNbtElement;
                     int otherWorldId = matchNbt.getInt("world").orElseThrow();
                     Match match = new Match(
-                            new LongOpenHashSet(worldNbt.getLongArray("matching").orElseThrow()),
-                            new LongOpenHashSet(worldNbt.getLongArray("mismatching").orElseThrow())
+                            new LongOpenHashSet(matchNbt.getLongArray("matching").orElseThrow()),
+                            new LongOpenHashSet(matchNbt.getLongArray("mismatching").orElseThrow())
                     );
 
                     World otherWorld = worlds.get(otherWorldId);


### PR DESCRIPTION
This fixes the network protocol error on server join and world change when Dynamic Multi World is enabled and there are existing saved chunks.

Resolves #366
Resolves #373 
Resolves #387
Resolves #397