### PR TITLE
Upgrade to Minecraft 1.21.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 5.2.11
+- Update to Minecraft 1.21.10
+
 ### 5.2.10
 - Update to Minecraft 1.21.9
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,12 @@ org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraftVersion = 1.21.9
-	yarnMappings = 1.21.9+build.1
-	loaderVersion = 0.17.2
+	minecraftVersion = 1.21.10
+	yarnMappings = 1.21.10+build.3
+	loaderVersion = 0.18.1
 
 # Mod Properties
-	modVersion = 5.2.10
+	modVersion = 5.2.11
 	mavenGroup = de.johni0702.minecraft
 	archivesBaseName = bobby
 	github.owner = johni0702
@@ -19,12 +19,12 @@ org.gradle.jvmargs=-Xmx2G
 	# modrinth.token = ***
 
 # Dependencies
-	fabricApiVersion = 0.133.14+1.21.9
+	fabricApiVersion = 0.138.3+1.21.10
 	configurateVersion = 4.1.2
 	geantyrefVersion = 1.3.13
 	hoconVersion = 1.4.2
 	confabricateVersion = 2.1.0
-	clothConfigVersion = 19.0.147
-	modMenuVersion = 15.0.0-beta.3
-	sodium06Version = mc1.21.9-0.7.0-fabric
+	clothConfigVersion = 20.0.149
+	modMenuVersion = 16.0.0-rc.1
+	sodium06Version = mc1.21.10-0.7.3-fabric
 	starlightVersion = 1.1.3+1.20.3

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,8 +32,8 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.16.9",
-    "minecraft": "~1.21.9"
+    "fabricloader": ">=0.18.1",
+    "minecraft": "~1.21.10"
   },
   "suggests": {
     "cloth-config2": "^${clothConfigVersion}",


### PR DESCRIPTION
This pull request updates the mod to support Minecraft 1.21.10 and synchronizes all related dependencies and metadata. The changes are focused on version upgrades to ensure compatibility with the latest game release and its ecosystem.

**Minecraft and Loader Version Updates:**
* Updated `minecraftVersion` to 1.21.10 and `fabricloader` to 0.18.1 in both `gradle.properties` and `fabric.mod.json` for compatibility with the latest Minecraft release. [[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L5-R10) [[2]](diffhunk://#diff-882c6606823cf6c4e4114c1125850a04ed3180c48aef0e1467f1e4022b235db2L35-R36)

**Dependency Upgrades:**
* Bumped versions for key dependencies: `fabricApiVersion`, `clothConfigVersion`, `modMenuVersion`, and `sodium06Version` to match the new Minecraft version and ensure stability.

**Metadata and Documentation:**
* Updated `modVersion` in `gradle.properties` and added a new entry to `CHANGELOG.md` for version 5.2.11, documenting the update to Minecraft 1.21.10. [[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L5-R10) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R3)