### PR TITLE
fix: catch ReportedNbtException around NBT reads

### DIFF
--- a/src/main/java/de/johni0702/minecraft/bobby/Worlds.java
+++ b/src/main/java/de/johni0702/minecraft/bobby/Worlds.java
@@ -31,6 +31,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.ReportedNbtException;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.Util;
@@ -945,7 +946,7 @@ public class Worlds implements AutoCloseable {
         if (Files.exists(metaFile)) {
             try (InputStream in = Files.newInputStream(metaFile)) {
                 return NbtIo.readCompressed(in, NbtAccounter.unlimitedHeap());
-            } catch (IOException e) {
+            } catch (IOException | ReportedNbtException e) {
                 LOGGER.error("Failed to read " + metaFile, e);
             }
         }
@@ -1489,7 +1490,7 @@ public class Worlds implements AutoCloseable {
             Path file = world.regionFile(regionPos);
             try {
                 result = Region.read(file, regionPos);
-            } catch (IOException e) {
+            } catch (IOException | ReportedNbtException e) {
                 LOGGER.error("Failed to load " + file, e);
             } finally {
                 if (result == null) {


### PR DESCRIPTION
Fixes a Network Protocol Error disconnect I noticed from a user with presumably corrupted saved world data that wasn't getting caught because Minecraft was re-throwing the EOFException as a ReportedNbtException.

Logs of the error before applying this patch: https://mclo.gs/4S3FraF