### PR TITLE
[mc26.1] Handle config and cache corruption safely

### DIFF
--- a/src/main/java/de/johni0702/minecraft/bobby/Bobby.java
+++ b/src/main/java/de/johni0702/minecraft/bobby/Bobby.java
@@ -29,6 +29,7 @@ import org.spongepowered.configurate.reference.WatchServiceListener;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -54,15 +55,21 @@ public class Bobby implements ClientModInitializer {
 
     @Override
     public void onInitializeClient() {
+        Path configPath = FabricLoader.getInstance().getConfigDir().resolve(MOD_ID + ".conf");
         try {
-            Path configPath = FabricLoader.getInstance().getConfigDir().resolve(MOD_ID + ".conf");
             @SuppressWarnings("resource") // we'll keep this around for the entire lifetime of our mod
             ConfigurationReference<CommentedConfigurationNode> rootRef = getOrCreateWatchServiceListener()
                     .listenToConfiguration(path -> HoconConfigurationLoader.builder().path(path).build(), configPath);
             configReference = rootRef.referenceTo(BobbyConfig.class);
             rootRef.saveAsync();
         } catch (IOException e) {
-            e.printStackTrace();
+            Path corruptConfigPath = configPath.resolveSibling(configPath.getFileName() + ".corrupt");
+            try {
+                Files.move(configPath, corruptConfigPath, StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException moveException) {
+                e.addSuppressed(moveException);
+            }
+            LOGGER.error("Failed to initialize Bobby configuration at " + configPath + ", using defaults", e);
         }
 
         ClientCommandRegistrationCallback.EVENT.register(((dispatcher, registryAccess) ->
@@ -79,8 +86,10 @@ public class Bobby implements ClientModInitializer {
 
         FlawlessFrames.onClientInitialization();
 
-        configReference.subscribe(new TaintChunksConfigHandler()::update);
-        configReference.subscribe(new MaxRenderDistanceConfigHandler()::update);
+        if (configReference != null) {
+            configReference.subscribe(new TaintChunksConfigHandler()::update);
+            configReference.subscribe(new MaxRenderDistanceConfigHandler()::update);
+        }
 
         Util.ioPool().execute(this::cleanupOldWorlds);
     }
@@ -97,7 +106,7 @@ public class Bobby implements ClientModInitializer {
     }
 
     public Screen createConfigScreen(Screen parent) {
-        if (FabricLoader.getInstance().isModLoaded("cloth-config2")) {
+        if (FabricLoader.getInstance().isModLoaded("cloth-config2") && configReference != null) {
             return BobbyConfigScreenFactory.createConfigScreen(parent, getConfig(), configReference::setAndSaveAsync);
         }
         return null;

--- a/src/main/java/de/johni0702/minecraft/bobby/Worlds.java
+++ b/src/main/java/de/johni0702/minecraft/bobby/Worlds.java
@@ -31,6 +31,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.ReportedNbtException;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.Util;
@@ -145,7 +146,19 @@ public class Worlds implements AutoCloseable {
         this.directory = directory;
         this.metaFile = metaFile(directory);
 
-        load(readFromDisk());
+        CompoundTag root = readFromDisk();
+        if (root == null) {
+            load(null);
+        } else {
+            try {
+                load(root);
+            } catch (RuntimeException e) {
+                discardCorruptMetadata(metaFile, e);
+                worlds.clear();
+                outdatedWorlds.clear();
+                load(null);
+            }
+        }
 
         if (!outdatedWorlds.isEmpty()) {
             Component text = translatable("bobby.upgrade.required");
@@ -945,11 +958,20 @@ public class Worlds implements AutoCloseable {
         if (Files.exists(metaFile)) {
             try (InputStream in = Files.newInputStream(metaFile)) {
                 return NbtIo.readCompressed(in, NbtAccounter.unlimitedHeap());
-            } catch (IOException e) {
-                LOGGER.error("Failed to read " + metaFile, e);
+            } catch (IOException | ReportedNbtException e) {
+                discardCorruptMetadata(metaFile, e);
             }
         }
         return null;
+    }
+
+    private static void discardCorruptMetadata(Path file, Exception cause) {
+        try {
+            Files.deleteIfExists(file);
+        } catch (IOException e) {
+            cause.addSuppressed(e);
+        }
+        LOGGER.error("Failed to read " + file + ", discarding it", cause);
     }
 
     private void writeToDisk(CompoundTag nbt) throws IOException {
@@ -1417,6 +1439,12 @@ public class Worlds implements AutoCloseable {
             long[] chunkAges = root.getLongArray("chunk_ages").orElseGet(() -> new long[0]);
             long[] chunkFingerprints = root.getLongArray("chunk_fingerprints").orElseGet(() -> new long[0]);
 
+            if (chunkCoords.length != chunkAges.length || chunkCoords.length != chunkFingerprints.length) {
+                throw new IOException("Invalid region metadata: chunk array lengths differ (coords="
+                        + chunkCoords.length + ", ages=" + chunkAges.length
+                        + ", fingerprints=" + chunkFingerprints.length + ")");
+            }
+
             Region region = new Region();
             region.chunks.putAll(new Long2LongArrayMap(chunkCoords, chunkAges));
             region.chunkFingerprints.putAll(new Long2LongArrayMap(chunkCoords, chunkFingerprints));
@@ -1489,8 +1517,8 @@ public class Worlds implements AutoCloseable {
             Path file = world.regionFile(regionPos);
             try {
                 result = Region.read(file, regionPos);
-            } catch (IOException e) {
-                LOGGER.error("Failed to load " + file, e);
+            } catch (IOException | ReportedNbtException | IllegalArgumentException e) {
+                discardCorruptMetadata(file, e);
             } finally {
                 if (result == null) {
                     result = new Region();


### PR DESCRIPTION
## Summary

This applies the config and cache corruption fixes to the `mc-26.1` branch.

- Fall back to Bobby's default configuration when config initialization fails.
- Preserve the failed config as `bobby.conf.corrupt`.
- Handle checked and wrapped NBT decoding failures in world and region metadata.
- Recover when decoded world metadata has an invalid structure.
- Reject region metadata when its coordinate, age, and fingerprint arrays have different lengths.
- Delete invalid cache metadata and continue with empty metadata so the cache can be rebuilt.

## Context

The supplied crash reports use Bobby 5.2.13 on Minecraft 26.1.2 and cover:

- A null `configReference` during initialization.
- Corrupt or truncated compressed NBT.
- Region metadata arrays with different lengths.

Reported logs:

- https://mclo.gs/Q2snZkm
- https://mclo.gs/XfIOBeh
- https://mclo.gs/3grJwXn
- https://mclo.gs/VSFaFXN
- https://mclo.gs/3j2Z1Bu

## AI assistance

The fix was created with assistance from Codex and reviewed before submission.
